### PR TITLE
Update committee quorum

### DIFF
--- a/uwapcs_constitution.tex
+++ b/uwapcs_constitution.tex
@@ -130,7 +130,7 @@
 
 \begin{enumsection}{Committee Meetings}
     \item The Committee shall meet as such times and places as the President, in consultation with the other Committee members shall determine.
-    \item The quorum of a Committee meeting shall be 4 Committee members of which at least 2 must be executive office bearers.
+    \item The quorum of a Committee meeting shall be 5 Committee members of which at least 3 must be executive office bearers. Nonvoting Committee positions do not count towards quorum.
     \item The Committee shall only exercise its powers (as defined in this constitution or in Regulations) at a properly convened meeting of the Committee, except as elsewhere provided in the Constitution.
     \item The Secretary or President shall cause all members of the Committee to receive three days notice of any such meeting including an agenda of the business to be discussed. This agenda may be expanded upon during the meeting.
     \begin{enumerate}


### PR DESCRIPTION
Increase base and executive quorum requirements by one in order to require a majority. Currently we only require 50%, which is not sufficient to reasonably be considered a majority.

Add note specifying that nonvoting Committee positions do not count towards quorum, to make it explicit that IPP and any future nonvoting positions being present does not allow a sub-quorum of voting members to decide matters.